### PR TITLE
Handle float/int slice problem and null values

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -92,7 +92,7 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 
 func convertInt32To64(ar []int32) []float64 {
 	newar := make([]float64, len(ar))
-	var v float32
+	var v int32
 	var i int
 	for i, v = range ar {
 		newar[i] = float64(v)
@@ -102,7 +102,7 @@ func convertInt32To64(ar []int32) []float64 {
 
 func convertInt64To64(ar []int64) []float64 {
 	newar := make([]float64, len(ar))
-	var v float32
+	var v int64
 	var i int
 	for i, v = range ar {
 		newar[i] = float64(v)


### PR DESCRIPTION
Based on findings outlined here: https://github.com/pgollangi/firestore-grafana-datasource/issues/14#issuecomment-1714476560

I think this will handle the case where we values which are mostly ints, but we get a float, or we have mostly floats but get an int (this is possible because firebase will change floats which are even to ints, for instance if you try to save `400.0`, firebase will save it as `400`, and if all the other values in a collection are floats, we will have problems trying to append to the slice with the existing code.

I expect adding a null into the mix will cause a similar crash, so in this case, I just detected a nil and added a 0 or 0.0 depending on the slice type.

I'm not entirely sure there isn't also a problem in the fireql library that this uses as well - will try out to verify asap.